### PR TITLE
feat!: Upgrade to Node 20

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,15 +47,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  # Pulls all commits (needed for semantic release to correctly version)
-                  # See https://github.com/semantic-release/semantic-release/issues/1526
+                  # Pulls all commits and tags (needed for semantic release to correctly version)
                   fetch-depth: "0"
                   persist-credentials: false
-                  sparse-checkout: ''
-
-            # Pulls all tags (needed for semantic release to correctly version)
-            - name: Fetch git tags
-              run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+                  sparse-checkout: |
+                    README.md
 
             - name: Use Node.js 20
               uses: actions/setup-node@v4
@@ -70,10 +66,11 @@ jobs:
 
             - name: Display structure of downloaded files
               run: ls -R
+              working-directory: ./release
 
             - name: Release 🚀
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npx semantic-release@^22 --dry-run
+              run: npx semantic-release@^22 --dry-run --no-ci
               working-directory: ./release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,12 +17,12 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
-            - name: Use Node.js 18
-              uses: actions/setup-node@v3
+            - name: Use Node.js 20
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18.x
+                  node-version: 20.x
 
             - run: npm install
 
@@ -38,7 +38,7 @@ jobs:
             - test
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Pulls all commits (needed for semantic release to correctly version)
                   # See https://github.com/semantic-release/semantic-release/issues/1526
@@ -49,10 +49,10 @@ jobs:
             - name: Fetch git tags
               run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-            - name: Use Node.js 18
-              uses: actions/setup-node@v3
+            - name: Use Node.js 20
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18.x
+                  node-version: 20.x
 
             - run: npm install
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,7 @@ jobs:
                   # See https://github.com/semantic-release/semantic-release/issues/1526
                   fetch-depth: "0"
                   persist-credentials: false
+                  sparse-checkout: ''
 
             # Pulls all tags (needed for semantic release to correctly version)
             - name: Fetch git tags
@@ -65,6 +66,7 @@ jobs:
               uses: actions/download-artifact@v3
               with:
                   name: release
+                  path: release
 
             - name: Display structure of downloaded files
               run: ls -R

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,11 +32,18 @@ jobs:
 
             - run: npm run test
 
+            - run: cp LICENSE package.json README.md build
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: release
+                  path: build/
+
     release:
         runs-on: ubuntu-latest
         needs:
             - test
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
+        #if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         steps:
             - uses: actions/checkout@v4
               with:
@@ -54,15 +61,17 @@ jobs:
               with:
                   node-version: 20.x
 
-            - run: npm install
+            - name: Download release artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: release
 
-            - run: npm run build
-
-            - run: cp LICENSE package.json README.md build
+            - name: Display structure of downloaded files
+              run: ls -R
 
             - name: Release 🚀
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npx semantic-release@^19
-              working-directory: ./build
+              run: npx semantic-release@^22 --dry-run
+              working-directory: ./release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,12 +43,12 @@ jobs:
         runs-on: ubuntu-latest
         needs:
             - test
-        #if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         steps:
             - uses: actions/checkout@v4
               with:
                   # Pulls all commits and tags (needed for semantic release to correctly version)
-                  fetch-depth: "0"
+                  fetch-depth: 0
                   persist-credentials: false
                   sparse-checkout: |
                     README.md
@@ -64,13 +64,9 @@ jobs:
                   name: release
                   path: release
 
-            - name: Display structure of downloaded files
-              run: ls -R
-              working-directory: ./release
-
             - name: Release 🚀
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npx semantic-release@^22 --dry-run --no-ci
+              run: npx semantic-release@^22
               working-directory: ./release

--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,8 +2151,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -2168,9 +2166,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -12412,14 +12408,15 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
-            "requires": {},
+            "requires": {
+                "ajv": "^8.0.0"
+            },
             "dependencies": {
                 "ajv": {
-                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12431,9 +12428,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },


### PR DESCRIPTION
- Use Node 20. Technically this is not a breaking change for consumers of the package, but it is our convention to bump the major version when there is a Node major version bump.
- Switch workflow to store an artifact that is reused on release, rather than a duplicate build.