### PR TITLE
fix: update repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
     "description": "ArcGIS Utility Network activities for VertiGIS Studio Workflow",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/geocortex/workflow-activities-utility-network.git"
+        "url": "git+https://github.com/vertigis/workflow-activities-utility-network.git"
     },
     "license": "MIT",
     "author": "VertiGIS",
-    "homepage": "https://github.com/geocortex/workflow-activities-utility-network#readme",
+    "homepage": "https://github.com/vertigis/workflow-activities-utility-network#readme",
     "keywords": [
         "VertiGIS",
         "Geocortex",


### PR DESCRIPTION
This fixes a redirect issue encountered by `semantic-release` https://github.com/semantic-release/github/issues/746