### PR TITLE
feat: Add requestOptions and outSpatialReference to Run Utility Network Trace

### DIFF
--- a/src/activities/RunUtilityNetworkTrace.ts
+++ b/src/activities/RunUtilityNetworkTrace.ts
@@ -65,12 +65,24 @@ export interface RunUtilityNetworkTraceInputs {
      * @description The geodatabase version on which the operation will be performed.
      */
     gdbVersion?: string;
-
+    /**
+     * The spatial reference that should be used to project the aggregated geometries returned by the trace (if applicable).
+     */
+    outSpatialReference?: __esri.SpatialReference;
     /**
      * @displayName Moment
      * @description The date/timestamp (in UTC) to execute the trace at a given time.
      */
     moment?: number;
+    /**
+     * @description Additional options to be used for the request.
+     */
+    requestOptions?: {
+        /** The HTTP request method. The default is auto. */
+        method?: "auto" | "post" | string;
+        /** The amount of time in milliseconds to wait for a response from the server. Set to 0 to wait for the response indefinitely. The default is 60000. */
+        timeout?: number;
+    };
 
     /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
 }
@@ -98,11 +110,13 @@ export default class RunUtilityNetworkTrace implements IActivityHandler {
         const {
             gdbVersion,
             moment,
-            utilityNetwork,
+            outSpatialReference,
+            requestOptions,
+            resultTypes = [],
             traceType,
             traceLocations,
             traceConfiguration,
-            resultTypes = [],
+            utilityNetwork,
         } = inputs;
 
         if (!utilityNetwork) {
@@ -153,6 +167,7 @@ export default class RunUtilityNetworkTrace implements IActivityHandler {
             gdbVersion,
             moment,
             namedTraceConfigurationGlobalId,
+            outSpatialReference,
             resultTypes: resultTypes as any,
             traceConfiguration:
                 typeof traceConfiguration !== "string"
@@ -163,7 +178,8 @@ export default class RunUtilityNetworkTrace implements IActivityHandler {
         });
         const traceResult = await trace.trace(
             utilityNetwork.networkServiceUrl,
-            traceParams
+            traceParams,
+            requestOptions
         );
 
         return {

--- a/src/activities/__tests__/RunUtilityNetworkTrace.test.ts
+++ b/src/activities/__tests__/RunUtilityNetworkTrace.test.ts
@@ -1,6 +1,7 @@
 import RunUtilityNetworkTrace from "../RunUtilityNetworkTrace";
 import { RunUtilityNetworkTraceInputs } from "../RunUtilityNetworkTrace";
 import TraceResult from "@arcgis/core/rest/networks/support/TraceResult";
+import trace from "@arcgis/core/rest/networks/trace";
 
 const mockTraceLocation = {
     globalId: "abc",
@@ -62,6 +63,8 @@ jest.mock("@arcgis/core/rest/networks/trace", () => ({
         return {};
     },
 }));
+const traceSpy = jest.spyOn(trace, "trace");
+
 jest.mock("@arcgis/core/rest/networks/support/TraceResult", () => {
     return function () {
         return {};
@@ -136,6 +139,30 @@ describe("RunUtilityNetworkTrace", () => {
             expect(result).toStrictEqual({
                 traceResult: new TraceResult(),
             });
+        });
+        it("uses extra request options", async () => {
+            const inputs: RunUtilityNetworkTraceInputs = {
+                utilityNetwork: {
+                    networkServiceUrl: "https://foo",
+                } as any,
+                traceType: "isolation",
+                traceLocations: [],
+                traceConfiguration: {} as any,
+                requestOptions: { timeout: 1000 },
+                resultTypes: [],
+            };
+            const activity = new RunUtilityNetworkTrace();
+            const result = await activity.execute(inputs);
+            expect(result).toBeDefined();
+            expect(traceSpy).toHaveBeenCalledWith(
+                inputs.utilityNetwork.networkServiceUrl,
+                expect.objectContaining({
+                    traceConfiguration: expect.anything(),
+                    traceLocations: inputs.traceLocations,
+                    traceType: inputs.traceType,
+                }),
+                inputs.requestOptions
+            );
         });
     });
 });


### PR DESCRIPTION
Add `requestOptions` and `outSpatialReference` inputs to the Run Utility Network Trace activity.

Fixes #53